### PR TITLE
feat: fixing circular dependency and scss rollup build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7911,7 +7911,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7932,12 +7933,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7952,17 +7955,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8079,7 +8085,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8091,6 +8098,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8105,6 +8113,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8112,12 +8121,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8136,6 +8147,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8216,7 +8228,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8228,6 +8241,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8313,7 +8327,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8349,6 +8364,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8368,6 +8384,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8411,12 +8428,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/Button/AccentCoolButton.tsx
+++ b/src/Button/AccentCoolButton.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import Button from './Button';
-import '../index';
 
-interface AccentCoolButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  children: string
+interface AccentCoolButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: string;
 }
 
-const AccentCoolButton: React.FC<AccentCoolButtonProps> = ({ children, ...other }) => (
+const AccentCoolButton: React.FC<AccentCoolButtonProps> = ({
+  children,
+  ...other
+}) => (
   <Button className={'usa-button usa-button--accent-cool'} {...other}>
     {children}
   </Button>

--- a/src/Button/BaseButton.tsx
+++ b/src/Button/BaseButton.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import Button from './Button';
-import '../index';
 
-interface BaseButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  children: string
+interface BaseButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: string;
 }
 
 const BaseButton: React.FC<BaseButtonProps> = ({ children, ...other }) => (

--- a/src/Button/BigButton.tsx
+++ b/src/Button/BigButton.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import Button from './Button';
-import '../index';
 
 interface BigButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  children: string
+  children: string;
 }
 
 const BigButton: React.FC<BigButtonProps> = ({ children, ...other }) => (

--- a/src/Button/Button.story.tsx
+++ b/src/Button/Button.story.tsx
@@ -1,61 +1,41 @@
 import * as React from 'react';
-import * as Buttons from './';
+import {
+  DefaultButton,
+  SecondayButton,
+  AccentCoolButton,
+  BaseButton,
+  OutlineButton,
+  OutlineInverseButton,
+  BigButton,
+} from '../index';
 import { storiesOf } from '@storybook/react';
 
 const stories = storiesOf('Button', module);
 
 stories.add('Default', () => {
-  return (
-    <Buttons.DefaultButton >
-      {'Click Me'}
-    </Buttons.DefaultButton >
-  )
+  return <DefaultButton>{'Click Me'}</DefaultButton>;
 });
 
 stories.add('Secondary Color', () => {
-  return (
-    <Buttons.SecondayButton >
-      {'Click Me'}
-    </Buttons.SecondayButton >
-  )
+  return <SecondayButton>{'Click Me'}</SecondayButton>;
 });
 
 stories.add('Accent Cool Color', () => {
-  return (
-    <Buttons.AccentCoolButton >
-      {'Click Me'}
-    </Buttons.AccentCoolButton >
-  )
+  return <AccentCoolButton>{'Click Me'}</AccentCoolButton>;
 });
 
 stories.add('Base Color', () => {
-  return (
-    <Buttons.BaseButton >
-      {'Click Me'}
-    </Buttons.BaseButton >
-  )
+  return <BaseButton>{'Click Me'}</BaseButton>;
 });
 
 stories.add('Outline', () => {
-  return (
-    <Buttons.OutlineButton>
-      {'Click Me'}
-    </Buttons.OutlineButton >
-  )
+  return <OutlineButton>{'Click Me'}</OutlineButton>;
 });
 
 stories.add('Outline Inverse', () => {
-  return (
-    <Buttons.OutlineInverseButton >
-      {'Click Me'}
-    </Buttons.OutlineInverseButton >
-  )
+  return <OutlineInverseButton>{'Click Me'}</OutlineInverseButton>;
 });
 
 stories.add('Big Button', () => {
-  return (
-    <Buttons.BigButton >
-      {'Click Me'}
-    </Buttons.BigButton >
-  )
+  return <BigButton>{'Click Me'}</BigButton>;
 });

--- a/src/Button/DefaultButton.tsx
+++ b/src/Button/DefaultButton.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import Button from './Button';
-import '../index';
 
-interface DefaultButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  children: string
+interface DefaultButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: string;
 }
 
-const DefaultButton: React.FC<DefaultButtonProps> = ({ children, ...other }) => (
+const DefaultButton: React.FC<DefaultButtonProps> = ({
+  children,
+  ...other
+}) => (
   <Button className={'usa-button'} {...other}>
     {children}
   </Button>

--- a/src/Button/OutlineButton.tsx
+++ b/src/Button/OutlineButton.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import Button from './Button';
-import '../index';
 
-interface OutlineButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  children: string
+interface OutlineButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: string;
 }
 
-const OutlineButton: React.FC<OutlineButtonProps> = ({ children, ...other }) => (
+const OutlineButton: React.FC<OutlineButtonProps> = ({
+  children,
+  ...other
+}) => (
   <Button className={'usa-button usa-button--outline'} {...other}>
     {children}
   </Button>

--- a/src/Button/OutlineInverseButton.tsx
+++ b/src/Button/OutlineInverseButton.tsx
@@ -1,13 +1,19 @@
 import React from 'react';
 import Button from './Button';
-import '../index';
 
-interface OutlineInverseButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  children: string
+interface OutlineInverseButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: string;
 }
 
-const OutlineInverseButton: React.FC<OutlineInverseButtonProps> = ({ children, ...other }) => (
-  <Button className={'usa-button usa-button--outline usa-button--inverse'} {...other}>
+const OutlineInverseButton: React.FC<OutlineInverseButtonProps> = ({
+  children,
+  ...other
+}) => (
+  <Button
+    className={'usa-button usa-button--outline usa-button--inverse'}
+    {...other}
+  >
     {children}
   </Button>
 );

--- a/src/Button/SecondaryButton.tsx
+++ b/src/Button/SecondaryButton.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import Button from './Button';
-import '../index';
 
-interface SecondaryButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  children: string
+interface SecondaryButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: string;
 }
 
-const SecondaryButton: React.FC<SecondaryButtonProps> = ({ children, ...other }) => (
+const SecondaryButton: React.FC<SecondaryButtonProps> = ({
+  children,
+  ...other
+}) => (
   <Button className={'usa-button usa-button--secondary'} {...other}>
     {children}
   </Button>

--- a/tsdx.config.js
+++ b/tsdx.config.js
@@ -1,4 +1,5 @@
-import scss from 'rollup-plugin-scss';
+/* eslint-disable */
+const scss = require('rollup-plugin-scss');
 
 module.exports = {
   rollup(config) {


### PR DESCRIPTION
Fixing circular dependency in import statements for all buttons to not import from ../index. Then switched the stories to import from index of root src so it matches external implementation structure. 